### PR TITLE
Fixes for Python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ### Make Linux more user friendly with this collection of **Bash functions**!
 
-They provide **commands that should be in Linux** by default, or just **abbreviations of commands** that are provided, but are so commonly used that they deserve a shorter name and/or a set of configurable **sensible options**. When abbreviated command is executed, these predefined options are combined with the actual ones. Also most of the commands send their **output to a pager** if it doesn't fit the screen.
+They provide **commands that should be in Linux** by default, or just **abbreviations of commands** that are provided, but are so commonly used that they deserve a shorter name and/or a set of configurable **sensible options**. When abbreviated command is executed, these predefined options are combined with the actual ones. Also most of the commands send their **output to a pager** if it doesn't fit the screen.
 
 Collection was made for **Debian** based Linux (**Ubuntu**, **Mint**, ...) with **Gnome** desktop environment, but most commands will work on any system that has _Bash_ shell and _GNU Coreutils_ installed. For **macOS** see [instructions](#how-to-run-on-macos).
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ### Make Linux more user friendly with this collection of **Bash functions**!
 
-They provide **commands that should be in Linux** by default, or just **abbreviations of commands** that are provided, but are so commonly used that they deserve a shorter name and/or a set of configurable **sensible options** When abbreviated command is executed, these predefined options are combined with the actual ones. Also most of the commands send their **output to a pager** if it doesn't fit the screen.
+They provide **commands that should be in Linux** by default, or just **abbreviations of commands** that are provided, but are so commonly used that they deserve a shorter name and/or a set of configurable **sensible options**. When abbreviated command is executed, these predefined options are combined with the actual ones. Also most of the commands send their **output to a pager** if it doesn't fit the screen.
 
 Collection was made for **Debian** based Linux (**Ubuntu**, **Mint**, ...) with **Gnome** desktop environment, but most commands will work on any system that has _Bash_ shell and _GNU Coreutils_ installed. For **macOS** see [instructions](#how-to-run-on-macos).
 
@@ -104,7 +104,7 @@ Misc
 
 * Command-line completions are automatically assigned to functions, depending on what commands they use.
 
-* Commands for accessing the framework:
+* Commands for accessing the framework 
   * **`ty COMMAND`**  prints function's body (short for `type`),
   * **`rc`**  opens configuration file (`~/.standardrc`) in default editor,
   * **`fu`**  opens `standard_functions` in default editor.

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 
 ### Make Linux more user friendly with this collection of **Bash functions**!
 
-They provide **commands that should be in Linux** by default, or just **abbreviations of commands** that are provided, but are so commonly used that they deserve a shorter name and/or a set of configurable **Ã¢ÂÂsensibleÃ¢ÂÂ options**. When abbreviated command is executed, these predefined options are combined with the actual ones. Also most of the commands send their **output to a pager** if it doesn't fit the screen.
+They provide **commands that should be in Linux** by default, or just **abbreviations of commands** that are provided, but are so commonly used that they deserve a shorter name and/or a set of configurable **sensible options**. When abbreviated command is executed, these predefined options are combined with the actual ones. Also most of the commands send their **output to a pager** if it doesn't fit the screen.
 
 Collection was made for **Debian** based Linux (**Ubuntu**, **Mint**, ...) with **Gnome** desktop environment, but most commands will work on any system that has _Bash_ shell and _GNU Coreutils_ installed. For **macOS** see [instructions](#how-to-run-on-macos).
 
 There are currently **211 commands**.
 
-How toÃ¢ÂÂ¦
+How to:
 -------
 ### Install
 ```
@@ -98,20 +98,20 @@ How To Rename Commands
 
 Misc
 ----
-* Usually if function only makes Linux command easier to use, either by using a few Ã¢ÂÂsensibleÃ¢ÂÂ options, or just by sending output to a pager (if necessary), then it has the same name as command, but with number `1` appended at the end. Some examples are: `ps1`, `mkdir1`, `pgrep1`, `tree1`. Options for this commands are defined at the bottom of [`standardrc`](standard_rc#L328-L358) and can be customized by preference.
+* Usually if function only makes Linux command easier to use, either by using a few sensible options, or just by sending output to a pager (if necessary), then it has the same name as command, but with number `1` appended at the end. Some examples are: `ps1`, `mkdir1`, `pgrep1`, `tree1`. Options for this commands are defined at the bottom of [`standardrc`](standard_rc#L328-L358) and can be customized by preference.
 
 * **`cp`**, **`mv`**, **`rm`** and **`rmdir`** are the only functions that override already existing commands. They are all run in interactive mode, meaning you get asked for conformation before any destructive operation. If you want to execute them without this prompting, use `-f` (force) option. `rmdir` also deletes the directory contents.
 
 * Command-line completions are automatically assigned to functions, depending on what commands they use.
 
-* Commands for accessing the Ã¢ÂÂframeworkÃ¢ÂÂ:
-  * **`ty COMMAND`** Ã¢ÂÂ prints function's body (short for `type`),
-  * **`rc`** Ã¢ÂÂ opens configuration file (`~/.standardrc`) in default editor,
-  * **`fu`** Ã¢ÂÂ opens `standard_functions` in default editor.
+* Commands for accessing the framework:
+  * **`ty COMMAND`**  prints function's body (short for `type`),
+  * **`rc`**  opens configuration file (`~/.standardrc`) in default editor,
+  * **`fu`**  opens `standard_functions` in default editor.
 
 How It Works
 ------------
-After installation the Ã¢ÂÂframeworkÃ¢ÂÂ consists of three files:
+After installation the framework consists of three files:
 
 * [**`standard_functions`**](standard_functions): It contains _Bash_ functions with long descriptive names. It is located in projects directory.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ### Make Linux more user friendly with this collection of **Bash functions**!
 
-They provide **commands that should be in Linux** by default, or just **abbreviations of commands** that are provided, but are so commonly used that they deserve a shorter name and/or a set of configurable **sensible options**. When abbreviated command is executed, these predefined options are combined with the actual ones. Also most of the commands send their **output to a pager** if it doesn't fit the screen.
+They provide **commands that should be in Linux** by default, or just **abbreviations of commands** that are provided, but are so commonly used that they deserve a shorter name and/or a set of configurable **sensible options** When abbreviated command is executed, these predefined options are combined with the actual ones. Also most of the commands send their **output to a pager** if it doesn't fit the screen.
 
 Collection was made for **Debian** based Linux (**Ubuntu**, **Mint**, ...) with **Gnome** desktop environment, but most commands will work on any system that has _Bash_ shell and _GNU Coreutils_ installed. For **macOS** see [instructions](#how-to-run-on-macos).
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ### Make Linux more user friendly with this collection of **Bash functions**!
 
-They provide **commands that should be in Linux** by default, or just **abbreviations of commands** that are provided, but are so commonly used that they deserve a shorter name and/or a set of configurable **sensible options**. When abbreviated command is executed, these predefined options are combined with the actual ones. Also most of the commands send their **output to a pager** if it doesn't fit the screen.
+They provide **commands that should be in Linux** by default, or just **abbreviations of commands** that are provided, but are so commonly used that they deserve a shorter name and/or a set of configurable **sensible options**. When abbreviated command is executed, these predefined options are combined with the actual ones. Also most of the commands send their **output to a pager** if it doesn't fit the screen.
 
 Collection was made for **Debian** based Linux (**Ubuntu**, **Mint**, ...) with **Gnome** desktop environment, but most commands will work on any system that has _Bash_ shell and _GNU Coreutils_ installed. For **macOS** see [instructions](#how-to-run-on-macos).
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 
 ### Make Linux more user friendly with this collection of **Bash functions**!
 
-They provide **commands that should be in Linux** by default, or just **abbreviations of commands** that are provided, but are so commonly used that they deserve a shorter name and/or a set of configurable **“sensible” options**. When abbreviated command is executed, these predefined options are combined with the actual ones. Also most of the commands send their **output to a pager** if it doesn't fit the screen.
+They provide **commands that should be in Linux** by default, or just **abbreviations of commands** that are provided, but are so commonly used that they deserve a shorter name and/or a set of configurable **Ã¢ÂÂsensibleÃ¢ÂÂ options**. When abbreviated command is executed, these predefined options are combined with the actual ones. Also most of the commands send their **output to a pager** if it doesn't fit the screen.
 
 Collection was made for **Debian** based Linux (**Ubuntu**, **Mint**, ...) with **Gnome** desktop environment, but most commands will work on any system that has _Bash_ shell and _GNU Coreutils_ installed. For **macOS** see [instructions](#how-to-run-on-macos).
 
 There are currently **211 commands**.
 
-How to…
+How toÃ¢ÂÂ¦
 -------
 ### Install
 ```
@@ -98,20 +98,20 @@ How To Rename Commands
 
 Misc
 ----
-* Usually if function only makes Linux command easier to use, either by using a few “sensible” options, or just by sending output to a pager (if necessary), then it has the same name as command, but with number `1` appended at the end. Some examples are: `ps1`, `mkdir1`, `pgrep1`, `tree1`. Options for this commands are defined at the bottom of [`standardrc`](standard_rc#L328-L358) and can be customized by preference.
+* Usually if function only makes Linux command easier to use, either by using a few Ã¢ÂÂsensibleÃ¢ÂÂ options, or just by sending output to a pager (if necessary), then it has the same name as command, but with number `1` appended at the end. Some examples are: `ps1`, `mkdir1`, `pgrep1`, `tree1`. Options for this commands are defined at the bottom of [`standardrc`](standard_rc#L328-L358) and can be customized by preference.
 
 * **`cp`**, **`mv`**, **`rm`** and **`rmdir`** are the only functions that override already existing commands. They are all run in interactive mode, meaning you get asked for conformation before any destructive operation. If you want to execute them without this prompting, use `-f` (force) option. `rmdir` also deletes the directory contents.
 
 * Command-line completions are automatically assigned to functions, depending on what commands they use.
 
-* Commands for accessing the “framework”:
-  * **`ty COMMAND`** – prints function's body (short for `type`),
-  * **`rc`** – opens configuration file (`~/.standardrc`) in default editor,
-  * **`fu`** – opens `standard_functions` in default editor.
+* Commands for accessing the Ã¢ÂÂframeworkÃ¢ÂÂ:
+  * **`ty COMMAND`** Ã¢ÂÂ prints function's body (short for `type`),
+  * **`rc`** Ã¢ÂÂ opens configuration file (`~/.standardrc`) in default editor,
+  * **`fu`** Ã¢ÂÂ opens `standard_functions` in default editor.
 
 How It Works
 ------------
-After installation the “framework” consists of three files:
+After installation the Ã¢ÂÂframeworkÃ¢ÂÂ consists of three files:
 
 * [**`standard_functions`**](standard_functions): It contains _Bash_ functions with long descriptive names. It is located in projects directory.
 
@@ -149,6 +149,8 @@ brew install findutils --with-default-names
 brew install tree
 ...
 ```
+
+
 
 
 

--- a/scripts/parse-rc.py
+++ b/scripts/parse-rc.py
@@ -83,9 +83,9 @@ def generateMapOfCompletions(completions):
 #   * String with completion in form of: "complete -F _longopt".
 def deduceCompletion(line, lastLine, completions, existingCompletions):
   # Tokenizes line from '^' or '|' or '$(' to "$@".
-  line = re.sub('"\$@".*$',"",line.strip())
-  line = re.sub('^.*\|',"",line.strip())
-  line = re.sub('^.*\$\(',"",line.strip())
+  line = re.sub(r'"\$@".*$',"",line.strip())
+  line = re.sub(r'^.*\|',"",line.strip())
+  line = re.sub(r'^.*\$\(',"",line.strip())
   optionsAreOnOwnLine = line.startswith('-')
   if optionsAreOnOwnLine:
     line = lastLine.strip()[:-1]

--- a/scripts/update-rc.py
+++ b/scripts/update-rc.py
@@ -69,7 +69,7 @@ def getFunctions():
     # Picks up all the function names (ignores ___).
     if line.startswith("__") and not line.startswith("___"):
       line = line.strip()
-      functionName = re.sub('\(.*$', '', line).strip()
+      functionName = re.sub(r'\(.*$', '', line).strip()
       functionDescription = util.camelCaseToDescription(functionName)
       functionDescriptions.append(functionDescription)
   return functionDescriptions  
@@ -314,7 +314,7 @@ def getMapOfOptionsFromRc(rcContent):
 # Returns list of all functions that use the option variables.
 def getCommandsWithOptionVariables():
   setOfOptionVariables = util.OrderedSet()
-  for match in re.findall("_([A-Z_]+)_OPTIONS", "\n".join(functionsContent)):
+  for match in re.findall(r"_([A-Z_]+)_OPTIONS", "\n".join(functionsContent)):
     commandName = util.underscoreToCamelcase(match)
     setOfOptionVariables.add(commandName)
   return  setOfOptionVariables

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -25,7 +25,7 @@ def descriptionToCamelCase(command):
   words[0] = firstLetterToLowercase(words[0])
   out = "".join(words)
   out = re.sub(' ', '', out)
-  out = re.sub('\.', '', out)
+  out = re.sub(r'\.', '', out)
   return "__"+out
 
 # Converts text in form of camel case into a sentence (First
@@ -33,7 +33,7 @@ def descriptionToCamelCase(command):
 # ends with period).
 def camelCaseToDescription(command):
   command = command.strip('_')
-  command = re.sub(r'([A-Z])',r' \1',command)
+  command = re.sub('([A-Z])',r' \1',command)
   command = command.lower()
   return firstLetterToUppercase(command)+"."
 
@@ -62,6 +62,8 @@ def camelcaseToUnderscore(command):
   return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
 
 import collections
+from collections.abc import MutableSet
+collections = collections.abc
 
 class OrderedSet(collections.MutableSet):
 


### PR DESCRIPTION
A second PR attempt after failing with the last. This time diffs are included, very minor changes in syntax and proper escaping. Also fixed deprecated Mutables class from collections.	

modified:   README.md
modified:   scripts/parse-rc.py
modified:   scripts/update-rc.py
modified:   scripts/util.py